### PR TITLE
fix co-lodash

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var _ = require('codash'),
+var _ = require('co-lodash'),
     through = require('through'),
     duplex = require('duplexer'),
     pause = require('pause-stream'),

--- a/lib/each-stream.js
+++ b/lib/each-stream.js
@@ -1,4 +1,4 @@
-var _ = require('codash'),
+var _ = require('co-lodash'),
     co = require('co'),
     util = require('util'),
     Writable = require('stream').Writable;

--- a/lib/map-stream.js
+++ b/lib/map-stream.js
@@ -1,4 +1,4 @@
-var _ = require('codash'),
+var _ = require('co-lodash'),
     util = require('util'),
     co = require('co'),
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "keywords": ["co", "stream", "event", "helper"],
   "dependencies": {
     "co": "^4.0.0",
-    "codash": "*",
+    "co-lodash": "*",
     "duplexer": "^0.1.1",
     "pause-stream": "0.0.11",
     "split": "^0.3.1",


### PR DESCRIPTION
> npm WARN deprecated codash@0.0.3: It's renamed to co-lodash

codash is updated to co-lodash
